### PR TITLE
[FEAT] canvas 읽기기능 종류별 추가

### DIFF
--- a/src/main/java/com/example/coconote/api/canvas/controller/CanvasController.java
+++ b/src/main/java/com/example/coconote/api/canvas/controller/CanvasController.java
@@ -11,6 +11,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -36,12 +38,14 @@ public class CanvasController {
     }
 
     @Operation(
-            summary = "채널 내 Canvas 리스트",
-            description = "채널 내 Canvas 리스트 확인하기"
+            summary = "채널 내 Canvas 리스트 - 1depth",
+            description = "채널 내 Canvas 리스트 확인하기 - 1depth 짜리만 조회"
     )
     @GetMapping("/{channelId}/list")
-    public ResponseEntity<?> getCanvasListInChannel(@PathVariable Long channelId, String email, Pageable pageable){
-        Page<CanvasListResDto> canvasListResDto = canvasService.getCanvasListInChannel(channelId, email, pageable);
+    public ResponseEntity<?> getCanvasListInChannel(@PathVariable Long channelId, String email,
+                                                    @PageableDefault(page = 0, size = 50, sort = "id", direction = Sort.Direction.ASC) Pageable pageable,
+                                                    @RequestParam(defaultValue = "0") Integer depth){
+        Page<CanvasListResDto> canvasListResDto = canvasService.getCanvasListInChannel(channelId, email, pageable, depth);
         CommonResDto commonResDto = new CommonResDto(HttpStatus.OK, "Canvas가 성공적으로 조회되었습니다.", canvasListResDto);
         return new ResponseEntity<>(commonResDto, HttpStatus.OK);
     }
@@ -50,7 +54,7 @@ public class CanvasController {
             summary = "현 캔버스를 참조하고 있는 하위 캔버스",
             description = "현 캔버스를 parentCanvas 로 참조 하고 있는 하위 Canvas 리스트 확인하기"
     )
-    @GetMapping("/{canvasId}/list")
+    @GetMapping("/{canvasId}/list/child")
     public ResponseEntity<?> getChildCanvasListFromCanvas(@PathVariable Long canvasId, String email){
 //        하위 캔버스는 전체 노출시키는 형식으로 진행
         List<CanvasListResDto> canvasListResDto = canvasService.getChildCanvasListFromCanvas(canvasId, email);
@@ -62,7 +66,7 @@ public class CanvasController {
             summary = "현 캔버스와 형제 캔버스",
             description = "현 캔버스의 parentCanvas 를 참조 하고 있는 하위 Canvas 리스트 확인하기"
     )
-    @GetMapping("/{canvasId}/list")
+    @GetMapping("/{canvasId}/list/sibling")
     public ResponseEntity<?> getChildCanvasListFromParentCanvas(@PathVariable Long canvasId, String email){
         List<CanvasListResDto> canvasListResDto = canvasService.getChildCanvasListFromParentCanvas(canvasId, email);
         CommonResDto commonResDto = new CommonResDto(HttpStatus.OK, "Canvas의 parentCanvas 기준으로 리스트가 성공적으로 조회되었습니다.", canvasListResDto);

--- a/src/main/java/com/example/coconote/api/canvas/controller/CanvasController.java
+++ b/src/main/java/com/example/coconote/api/canvas/controller/CanvasController.java
@@ -2,17 +2,20 @@ package com.example.coconote.api.canvas.controller;
 
 
 import com.example.coconote.api.canvas.dto.request.CreateCanvasReqDto;
+import com.example.coconote.api.canvas.dto.response.CanvasDetResDto;
+import com.example.coconote.api.canvas.dto.response.CanvasListResDto;
 import com.example.coconote.api.canvas.dto.response.CreateCanvasResDto;
 import com.example.coconote.api.canvas.service.CanvasService;
 import com.example.coconote.common.CommonResDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/canvas")
@@ -30,5 +33,50 @@ public class CanvasController {
         CreateCanvasResDto createCanvasResDto = canvasService.createCanvas(createCanvasReqDto, email);
         CommonResDto commonResDto = new CommonResDto(HttpStatus.CREATED, "Canvas가 성공적으로 생성되었습니다.", createCanvasResDto);
         return new ResponseEntity<>(commonResDto, HttpStatus.CREATED);
+    }
+
+    @Operation(
+            summary = "채널 내 Canvas 리스트",
+            description = "채널 내 Canvas 리스트 확인하기"
+    )
+    @GetMapping("/{channelId}/list")
+    public ResponseEntity<?> getCanvasListInChannel(@PathVariable Long channelId, String email, Pageable pageable){
+        Page<CanvasListResDto> canvasListResDto = canvasService.getCanvasListInChannel(channelId, email, pageable);
+        CommonResDto commonResDto = new CommonResDto(HttpStatus.OK, "Canvas가 성공적으로 조회되었습니다.", canvasListResDto);
+        return new ResponseEntity<>(commonResDto, HttpStatus.OK);
+    }
+
+    @Operation(
+            summary = "현 캔버스를 참조하고 있는 하위 캔버스",
+            description = "현 캔버스를 parentCanvas 로 참조 하고 있는 하위 Canvas 리스트 확인하기"
+    )
+    @GetMapping("/{canvasId}/list")
+    public ResponseEntity<?> getChildCanvasListFromCanvas(@PathVariable Long canvasId, String email){
+//        하위 캔버스는 전체 노출시키는 형식으로 진행
+        List<CanvasListResDto> canvasListResDto = canvasService.getChildCanvasListFromCanvas(canvasId, email);
+        CommonResDto commonResDto = new CommonResDto(HttpStatus.OK, "Canvas 기준으로 리스트가 성공적으로 조회되었습니다.", canvasListResDto);
+        return new ResponseEntity<>(commonResDto, HttpStatus.OK);
+    }
+
+    @Operation(
+            summary = "현 캔버스와 형제 캔버스",
+            description = "현 캔버스의 parentCanvas 를 참조 하고 있는 하위 Canvas 리스트 확인하기"
+    )
+    @GetMapping("/{canvasId}/list")
+    public ResponseEntity<?> getChildCanvasListFromParentCanvas(@PathVariable Long canvasId, String email){
+        List<CanvasListResDto> canvasListResDto = canvasService.getChildCanvasListFromParentCanvas(canvasId, email);
+        CommonResDto commonResDto = new CommonResDto(HttpStatus.OK, "Canvas의 parentCanvas 기준으로 리스트가 성공적으로 조회되었습니다.", canvasListResDto);
+        return new ResponseEntity<>(commonResDto, HttpStatus.OK);
+    }
+
+    @Operation(
+            summary = "Canvas 상세 읽기",
+            description = "Canvas 상세 읽기."
+    )
+    @GetMapping("/{canvasId}")
+    public ResponseEntity<?> getCanvasDetail(@PathVariable Long canvasId, String email){
+        CanvasDetResDto canvasDetResDto = canvasService.getCanvasDetail(canvasId, email);
+        CommonResDto commonResDto = new CommonResDto(HttpStatus.OK, "Canvas가 성공적으로 조회되었습니다.", canvasDetResDto);
+        return new ResponseEntity<>(commonResDto, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/coconote/api/canvas/dto/response/CanvasDetResDto.java
+++ b/src/main/java/com/example/coconote/api/canvas/dto/response/CanvasDetResDto.java
@@ -1,15 +1,27 @@
 package com.example.coconote.api.canvas.dto.response;
 
+import com.example.coconote.api.canvas.entity.Canvas;
+import com.example.coconote.api.channel.entity.Channel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class CanvasResDto {
+public class CanvasDetResDto {
     private Long id;
     private String title;
+
+    private Canvas parentCanvas;
+    private Channel channel;
+
+//    ⭐ 추후 블록 내용 추가
+
+    private LocalDateTime createdTime;
+    private LocalDateTime updatedTime;
 }

--- a/src/main/java/com/example/coconote/api/canvas/dto/response/CanvasDetResDto.java
+++ b/src/main/java/com/example/coconote/api/canvas/dto/response/CanvasDetResDto.java
@@ -1,0 +1,15 @@
+package com.example.coconote.api.canvas.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CanvasResDto {
+    private Long id;
+    private String title;
+}

--- a/src/main/java/com/example/coconote/api/canvas/dto/response/CanvasDetResDto.java
+++ b/src/main/java/com/example/coconote/api/canvas/dto/response/CanvasDetResDto.java
@@ -1,6 +1,7 @@
 package com.example.coconote.api.canvas.dto.response;
 
 import com.example.coconote.api.canvas.entity.Canvas;
+import com.example.coconote.api.channel.dto.response.ChannelResDto;
 import com.example.coconote.api.channel.entity.Channel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,8 +18,8 @@ public class CanvasDetResDto {
     private Long id;
     private String title;
 
-    private Canvas parentCanvas;
-    private Channel channel;
+    private CanvasListResDto parentCanvas;
+    private ChannelResDto channel;
 
 //    ⭐ 추후 블록 내용 추가
 

--- a/src/main/java/com/example/coconote/api/canvas/dto/response/CanvasListResDto.java
+++ b/src/main/java/com/example/coconote/api/canvas/dto/response/CanvasListResDto.java
@@ -1,0 +1,15 @@
+package com.example.coconote.api.canvas.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CanvasResDto {
+    private Long id;
+    private String title;
+}

--- a/src/main/java/com/example/coconote/api/canvas/dto/response/CanvasListResDto.java
+++ b/src/main/java/com/example/coconote/api/canvas/dto/response/CanvasListResDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class CanvasResDto {
+public class CanvasListResDto {
     private Long id;
     private String title;
 }

--- a/src/main/java/com/example/coconote/api/canvas/entity/Canvas.java
+++ b/src/main/java/com/example/coconote/api/canvas/entity/Canvas.java
@@ -1,7 +1,10 @@
 package com.example.coconote.api.canvas.entity;
 
+import com.example.coconote.api.canvas.dto.response.CanvasDetResDto;
+import com.example.coconote.api.canvas.dto.response.CanvasListResDto;
 import com.example.coconote.api.channel.entity.Channel;
 import com.example.coconote.api.drive.entity.Folder;
+import com.example.coconote.api.member.entity.Member;
 import com.example.coconote.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -22,10 +25,32 @@ public class Canvas extends BaseEntity {
     private String title;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "create_member_id")
+    private Member createMember;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_canvas_id")
     private Canvas parentCanvas;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Channel channel;
 
+    public CanvasListResDto fromListEntity() {
+        return CanvasListResDto.builder()
+                .id(this.id)
+                .title(this.title)
+                .build();
+    }
+
+    public CanvasDetResDto fromDetEntity() {
+        return CanvasDetResDto.builder()
+                .id(this.id)
+                .title(this.title)
+                .parentCanvas(this.getParentCanvas())
+                .channel(this.getChannel())
+//               ⭐ 추후 블록 추가
+                .createdTime(this.getCreatedTime())
+                .updatedTime(this.getUpdatedTime())
+                .build();
+    }
 }

--- a/src/main/java/com/example/coconote/api/canvas/entity/Canvas.java
+++ b/src/main/java/com/example/coconote/api/canvas/entity/Canvas.java
@@ -46,8 +46,8 @@ public class Canvas extends BaseEntity {
         return CanvasDetResDto.builder()
                 .id(this.id)
                 .title(this.title)
-                .parentCanvas(this.getParentCanvas())
-                .channel(this.getChannel())
+                .parentCanvas(this.getParentCanvas() != null ? this.getParentCanvas().fromListEntity() : null)
+                .channel(this.getChannel()!= null ? this.getChannel().fromEntity() : null)
 //               ⭐ 추후 블록 추가
                 .createdTime(this.getCreatedTime())
                 .updatedTime(this.getUpdatedTime())

--- a/src/main/java/com/example/coconote/api/canvas/repository/CanvasRepository.java
+++ b/src/main/java/com/example/coconote/api/canvas/repository/CanvasRepository.java
@@ -1,10 +1,15 @@
 package com.example.coconote.api.canvas.repository;
 
 import com.example.coconote.api.canvas.entity.Canvas;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CanvasRepository extends JpaRepository<Canvas,Long> {
-
+    Page<Canvas> findByChannelIdAndParentCanvasId(Pageable pageable, Long channelId, Long parentCanvasId);
+    List<Canvas> findByParentCanvasId(Long parentCanvasId);
 }

--- a/src/main/java/com/example/coconote/api/canvas/repository/CanvasRepository.java
+++ b/src/main/java/com/example/coconote/api/canvas/repository/CanvasRepository.java
@@ -12,4 +12,6 @@ import java.util.List;
 public interface CanvasRepository extends JpaRepository<Canvas,Long> {
     Page<Canvas> findByChannelIdAndParentCanvasId(Pageable pageable, Long channelId, Long parentCanvasId);
     List<Canvas> findByParentCanvasId(Long parentCanvasId);
+    List<Canvas> findByParentCanvasIdAndChannelId(Long parentCanvasId, Long channelId);
+
 }

--- a/src/main/java/com/example/coconote/api/channel/dto/response/ChannelResDto.java
+++ b/src/main/java/com/example/coconote/api/channel/dto/response/ChannelResDto.java
@@ -1,18 +1,14 @@
-package com.example.coconote.api.canvas.dto.response;
+package com.example.coconote.api.channel.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Data
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class CanvasListResDto {
+public class ChannelResDto {
     private Long id;
-    private String title;
-//    private List<CanvasListResDto> childCanvas;
 }

--- a/src/main/java/com/example/coconote/api/channel/entity/Channel.java
+++ b/src/main/java/com/example/coconote/api/channel/entity/Channel.java
@@ -1,5 +1,7 @@
 package com.example.coconote.api.channel.entity;
 
+import com.example.coconote.api.canvas.entity.Canvas;
+import com.example.coconote.api.channel.dto.response.ChannelResDto;
 import com.example.coconote.api.drive.entity.Folder;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -23,4 +25,14 @@ public class Channel {
     // 폴더들과의 관계 (일대다 관계)
     @OneToMany(mappedBy = "channel", cascade = CascadeType.ALL)
     private List<Folder> folders;
+
+    // 캔버스 관계
+    @OneToMany(mappedBy = "channel", cascade = CascadeType.ALL)
+    private List<Canvas> canvas;
+
+    public ChannelResDto fromEntity() {
+        return ChannelResDto.builder()
+                .id(this.id)
+                .build();
+    }
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
1. 캔버스 채널별 리스트
2. 특정 캔버스 하위 캔버스
3. 특정 캔버스 형제 캔버스
4. 특정 캔버스 상세

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
1. 캔버스 채널별 리스트
    ![image](https://github.com/user-attachments/assets/eb7ff5b1-2356-43eb-a3e8-4d48e214a463)
2. 특정 캔버스 하위 캔버스
    ![image](https://github.com/user-attachments/assets/59ecaffd-e16d-4e5c-a93b-9a4395de6cfc)
3. 특정 캔버스 형제 캔버스
    ![image](https://github.com/user-attachments/assets/ed46ff11-9a1a-4c08-8ca8-9729b5971bce)
4. 특정 캔버스 상세
    ![image](https://github.com/user-attachments/assets/caa077eb-90c8-405c-89c0-e662479ebc73)


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->
- 파일 생성이랑 수정이랑 같은이름으로 커밋이력 올라갔어요, 같은 이름 커밋은 첫 커밋 말고 두번째 커밋만 확인하면 됩니다.
- channel cascade 이슈로 channel에 dto 하나 만들었습니당

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/HC-71
