### PR TITLE
[FEAT] HC-73 블록 생성 및 업데이트, nextBlock을 prevBlock 형식으로 변경

### DIFF
--- a/src/main/java/com/example/coconote/api/block/controller/BlockController.java
+++ b/src/main/java/com/example/coconote/api/block/controller/BlockController.java
@@ -1,0 +1,34 @@
+package com.example.coconote.api.block.controller;
+
+import com.example.coconote.api.block.dto.request.CreateBlockReqDto;
+import com.example.coconote.api.block.dto.response.CreateBlockResDto;
+import com.example.coconote.api.block.service.BlockService;
+import com.example.coconote.api.canvas.dto.request.CreateCanvasReqDto;
+import com.example.coconote.common.CommonResDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/block")
+@RequiredArgsConstructor
+public class BlockController {
+
+    private final BlockService blockService;
+
+    @Operation(
+            summary = "Block 생성",
+            description = "새로운 Block 생성."
+    )
+    @PostMapping("/create")
+    public ResponseEntity<?> createBlock(@RequestBody CreateBlockReqDto createBlockReqDto, String email){
+        CreateBlockResDto createBlockResDto = blockService.createBlock(createBlockReqDto, email);
+        CommonResDto commonResDto = new CommonResDto(HttpStatus.CREATED, "Block이 성공적으로 생성되었습니다.", createBlockResDto);
+        return new ResponseEntity<>(commonResDto, HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/example/coconote/api/block/controller/BlockController.java
+++ b/src/main/java/com/example/coconote/api/block/controller/BlockController.java
@@ -1,6 +1,7 @@
 package com.example.coconote.api.block.controller;
 
 import com.example.coconote.api.block.dto.request.CreateBlockReqDto;
+import com.example.coconote.api.block.dto.request.UpdateBlockReqDto;
 import com.example.coconote.api.block.dto.response.CreateBlockResDto;
 import com.example.coconote.api.block.service.BlockService;
 import com.example.coconote.api.canvas.dto.request.CreateCanvasReqDto;
@@ -9,10 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/block")
@@ -31,4 +29,16 @@ public class BlockController {
         CommonResDto commonResDto = new CommonResDto(HttpStatus.CREATED, "Block이 성공적으로 생성되었습니다.", createBlockResDto);
         return new ResponseEntity<>(commonResDto, HttpStatus.CREATED);
     }
+
+    @Operation(
+            summary = "Block Update",
+            description = "기존 Block Update."
+    )
+    @PatchMapping("/{blockId}/update")
+    public ResponseEntity<?> updateBlock(@PathVariable String email, @RequestBody UpdateBlockReqDto updateBlockReqDto){
+        Boolean isUpdated = blockService.updateBlock(updateBlockReqDto, email);
+        CommonResDto commonResDto = new CommonResDto(HttpStatus.OK, "Block이 성공적으로 업데이트 되었습니다.", isUpdated);
+        return new ResponseEntity<>(commonResDto, HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/example/coconote/api/block/dto/request/CreateBlockReqDto.java
+++ b/src/main/java/com/example/coconote/api/block/dto/request/CreateBlockReqDto.java
@@ -1,0 +1,18 @@
+package com.example.coconote.api.block.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CreateBlockReqDto {
+    private Long canvasId;
+    private Long nextBlockId;
+    private Long parentBlockId;
+
+    private String contents;
+}

--- a/src/main/java/com/example/coconote/api/block/dto/request/UpdateBlockReqDto.java
+++ b/src/main/java/com/example/coconote/api/block/dto/request/UpdateBlockReqDto.java
@@ -9,10 +9,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class CreateBlockReqDto {
-    private Long canvasId;
+public class UpdateBlockReqDto {
+    private Long blockId;
     private Long prevBlockId;
     private Long parentBlockId;
-
     private String contents;
 }

--- a/src/main/java/com/example/coconote/api/block/dto/response/CreateBlockResDto.java
+++ b/src/main/java/com/example/coconote/api/block/dto/response/CreateBlockResDto.java
@@ -23,7 +23,7 @@ public class CreateBlockResDto {
         return CreateBlockResDto.builder()
                 .blockId(block.getId())
                 .canvasId(block.getCanvas().getId())
-                .nextBlockId(block.getNextBlock() == null ? null : block.getNextBlock().getId())
+                .nextBlockId(block.getPrevBlock() == null ? null : block.getPrevBlock().getId())
                 .parentBlockId(block.getParentBlock() == null ? null : block.getParentBlock().getId())
                 .contents(block.getContents())
                 .build();

--- a/src/main/java/com/example/coconote/api/block/dto/response/CreateBlockResDto.java
+++ b/src/main/java/com/example/coconote/api/block/dto/response/CreateBlockResDto.java
@@ -1,0 +1,31 @@
+package com.example.coconote.api.block.dto.response;
+
+import com.example.coconote.api.block.entity.Block;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CreateBlockResDto {
+    private Long blockId;
+
+    private Long canvasId;
+    private Long nextBlockId;
+    private Long parentBlockId;
+
+    private String contents;
+
+    public static CreateBlockResDto fromEntity(Block block) {
+        return CreateBlockResDto.builder()
+                .blockId(block.getId())
+                .canvasId(block.getCanvas().getId())
+                .nextBlockId(block.getNextBlock() == null ? null : block.getNextBlock().getId())
+                .parentBlockId(block.getParentBlock() == null ? null : block.getParentBlock().getId())
+                .contents(block.getContents())
+                .build();
+    }
+}

--- a/src/main/java/com/example/coconote/api/block/entity/Block.java
+++ b/src/main/java/com/example/coconote/api/block/entity/Block.java
@@ -8,6 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.Objects;
+
 @Entity
 @AllArgsConstructor
 @NoArgsConstructor
@@ -25,10 +27,31 @@ public class Block extends BaseEntity {
     private String contents;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "next_block_id")
-    private Block nextBlock; // 순서를 알기 위한, 동레벨의 다음 블록
+    @JoinColumn(name = "prev_block_id")
+//    순서를 알기 위한, 동레벨의 이전 블록
+//    이전 블록이 없다면, 최상위 블록!
+    private Block prevBlock;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "parent_block_id")
     private Block parentBlock;
+
+    public void changePrevBlock(Block block) {
+        this.prevBlock = block;
+    }
+
+    public void updateAllInfo(Block prevBlock, Block parentBlock, String contents) {
+        if(this.prevBlock != null && !Objects.equals(this.prevBlock.getId(), prevBlock.getId())){
+            this.prevBlock = prevBlock;
+        }
+
+        if(this.parentBlock != null && !Objects.equals(this.parentBlock.getId(), parentBlock.getId())){
+            this.parentBlock = parentBlock;
+        }
+
+        if(!Objects.equals(this.contents, contents)){
+            this.contents = contents;
+        }
+    }
+
 }

--- a/src/main/java/com/example/coconote/api/block/entity/Block.java
+++ b/src/main/java/com/example/coconote/api/block/entity/Block.java
@@ -1,0 +1,34 @@
+package com.example.coconote.api.block.entity;
+
+import com.example.coconote.api.canvas.entity.Canvas;
+import com.example.coconote.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class Block extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "canvas_id")
+    private Canvas canvas;
+
+    private String contents;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "next_block_id")
+    private Block nextBlock; // 순서를 알기 위한, 동레벨의 다음 블록
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_block_id")
+    private Block parentBlock;
+}

--- a/src/main/java/com/example/coconote/api/block/repository/BlockRepository.java
+++ b/src/main/java/com/example/coconote/api/block/repository/BlockRepository.java
@@ -4,7 +4,9 @@ import com.example.coconote.api.block.entity.Block;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface BlockRepository extends JpaRepository<Block,Long> {
-
+    Optional<Block> findByPrevBlockId(Long prevBlockId);
 }

--- a/src/main/java/com/example/coconote/api/block/repository/BlockRepository.java
+++ b/src/main/java/com/example/coconote/api/block/repository/BlockRepository.java
@@ -1,0 +1,10 @@
+package com.example.coconote.api.block.repository;
+
+import com.example.coconote.api.block.entity.Block;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BlockRepository extends JpaRepository<Block,Long> {
+
+}

--- a/src/main/java/com/example/coconote/api/block/service/BlockService.java
+++ b/src/main/java/com/example/coconote/api/block/service/BlockService.java
@@ -7,7 +7,6 @@ import com.example.coconote.api.block.entity.Block;
 import com.example.coconote.api.block.repository.BlockRepository;
 import com.example.coconote.api.canvas.entity.Canvas;
 import com.example.coconote.api.canvas.service.CanvasService;
-import jakarta.persistence.EntityNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,14 +33,31 @@ public class BlockService {
                     .orElseThrow(() -> new IllegalArgumentException("해당 부모 Block이 존재하지 않습니다."));
         }
 
+        Block prevBlock = null;
+        if(createBlockReqDto.getPrevBlockId() != null){
+            prevBlock = blockRepository.findById(createBlockReqDto.getPrevBlockId())
+                    .orElseThrow(() -> new IllegalArgumentException("해당 이전 Block이 존재하지 않습니다."));
+
+
+        }
+
 
         // 나머지 Block 생성 로직
         Block block = Block.builder()
                 .canvas(canvas)
                 .contents(createBlockReqDto.getContents())
-                .nextBlock(null)
+                .prevBlock(prevBlock)
                 .parentBlock(parentBlock)
                 .build();
+
+//        prev block 존재 및 이전에 해당 prev block을 갖고있는 block 주소 업데이트
+        if(prevBlock != null){
+            Block originalPrevBlockHolder = blockRepository.findByPrevBlockId(prevBlock.getId())
+                    .orElse(null);
+            if(originalPrevBlockHolder != null){
+                originalPrevBlockHolder.changePrevBlock(block);
+            }
+        }
 
         // Block 저장 및 리턴
         blockRepository.save(block);
@@ -49,6 +65,22 @@ public class BlockService {
         return CreateBlockResDto.fromEntity(block);
     }
 
+    @Transactional
+    public Boolean updateBlock(UpdateBlockReqDto updateBlockReqDto, String email){
+        Block block = blockRepository.findById(updateBlockReqDto.getBlockId()).orElseThrow(() -> new IllegalArgumentException("해당 Block이 존재하지 않습니다."));
+        Block prevBlock = updateBlockReqDto.getPrevBlockId() != null
+                ? blockRepository.findById(updateBlockReqDto.getPrevBlockId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 Prev Block이 존재하지 않습니다."))
+                : null;
 
+        Block parentBlock = updateBlockReqDto.getParentBlockId() != null
+                ? blockRepository.findById(updateBlockReqDto.getParentBlockId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 Parent Block이 존재하지 않습니다."))
+                : null;
+
+        block.updateAllInfo(prevBlock, parentBlock, updateBlockReqDto.getContents());
+
+        return true;
+    }
 
 }

--- a/src/main/java/com/example/coconote/api/block/service/BlockService.java
+++ b/src/main/java/com/example/coconote/api/block/service/BlockService.java
@@ -1,0 +1,54 @@
+package com.example.coconote.api.block.service;
+
+import com.example.coconote.api.block.dto.request.CreateBlockReqDto;
+import com.example.coconote.api.block.dto.request.UpdateBlockReqDto;
+import com.example.coconote.api.block.dto.response.CreateBlockResDto;
+import com.example.coconote.api.block.entity.Block;
+import com.example.coconote.api.block.repository.BlockRepository;
+import com.example.coconote.api.canvas.entity.Canvas;
+import com.example.coconote.api.canvas.service.CanvasService;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class BlockService {
+
+    private final CanvasService canvasService;
+    private final BlockRepository blockRepository;
+
+    public BlockService(CanvasService canvasService, BlockRepository blockRepository){
+        this.canvasService = canvasService;
+        this.blockRepository = blockRepository;
+    }
+
+    @Transactional
+    public CreateBlockResDto createBlock(CreateBlockReqDto createBlockReqDto, String email){
+        Canvas canvas = canvasService.findByIdAndIsDeletedReturnRequired(createBlockReqDto.getCanvasId());
+
+        Block parentBlock = null;
+        if (createBlockReqDto.getParentBlockId() != null) {
+            // parentBlockId가 null이 아니면 findById 호출
+            parentBlock = blockRepository.findById(createBlockReqDto.getParentBlockId())
+                    .orElseThrow(() -> new IllegalArgumentException("해당 부모 Block이 존재하지 않습니다."));
+        }
+
+
+        // 나머지 Block 생성 로직
+        Block block = Block.builder()
+                .canvas(canvas)
+                .contents(createBlockReqDto.getContents())
+                .nextBlock(null)
+                .parentBlock(parentBlock)
+                .build();
+
+        // Block 저장 및 리턴
+        blockRepository.save(block);
+
+        return CreateBlockResDto.fromEntity(block);
+    }
+
+
+
+}

--- a/src/main/java/com/example/coconote/api/canvas/service/CanvasService.java
+++ b/src/main/java/com/example/coconote/api/canvas/service/CanvasService.java
@@ -30,6 +30,7 @@ public class CanvasService {
         this.channelRepository = channelRepository;
     }
 
+    @Transactional
     public CreateCanvasResDto createCanvas(CreateCanvasReqDto createCanvasReqDto, String email){
         Channel channel = channelRepository.findById(createCanvasReqDto.getChannelId()).orElseThrow(() -> new IllegalArgumentException("채널이 존재하지 않습니다."));
 
@@ -112,4 +113,16 @@ public class CanvasService {
                 .orElseThrow(() -> new IllegalArgumentException("캔버스가 존재하지 않습니다."));
         canvas.markAsDeleted(); // 실제 삭제 대신 소프트 삭제 처리
     }
+
+
+//    ========== 기능 불러와서 쓰기~
+
+    public Canvas findByIdAndIsDeletedReturnRequired(Long canvasId){
+        return canvasRepository.findById(canvasId).orElseThrow(() -> new IllegalArgumentException("캔버스가 존재하지 않습니다."));
+    }
+
+    public Canvas findByIdAndIsDeletedReturnOrElseNull(Long canvasId){
+        return canvasRepository.findById(canvasId).orElse(null);
+    }
+
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
1. 블록 기본 틀 및 생성 기능
2. nextBlock을 prevBlock으로 변경
3. 블록업데이트 API 진행 

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
![image](https://github.com/user-attachments/assets/56d26b6a-d664-4e95-9539-47d8703cab27)


## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->
- 일단 기본적인 틀이랑 update만 구현해 놓았고, 이제 front repo로 넘어가서 세팅 진행할 예쩡입니당

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/hc-73