### PR TITLE
[FEAT] HC-109 사용자정보 어노테이션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'  // JSON 처리에 필요
+
+    //  어노테이션
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/coconote/api/member/controller/MemberController.java
+++ b/src/main/java/com/example/coconote/api/member/controller/MemberController.java
@@ -1,19 +1,17 @@
 package com.example.coconote.api.member.controller;
 
-import com.example.coconote.api.thread.service.ThreadService;
+import com.example.coconote.security.entity.CustomPrincipal;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("api/v1/member")
+@RequestMapping("/api/v1/member")
 @RequiredArgsConstructor
 public class MemberController {
-    private final ThreadService threadService;
 
-    @PostMapping("create")
-    public String create() {
-        return "create";
+    @GetMapping("/me")
+    public String getMemberInfo(@AuthenticationPrincipal CustomPrincipal customPrincipal) {
+        return "Logged in user: " + customPrincipal.getEmail() + ", Member ID: " + customPrincipal.getMemberId() + ", Member Nickname: " + customPrincipal.getNickname();
     }
 }

--- a/src/main/java/com/example/coconote/common/CommonExceptionHandler.java
+++ b/src/main/java/com/example/coconote/common/CommonExceptionHandler.java
@@ -1,12 +1,10 @@
 package com.example.coconote.common;
 
-
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-
 
 // @ControllerAdvice : 모든 컨트롤러에 적용되는 예외처리 클래스
 @ControllerAdvice
@@ -24,5 +22,4 @@ public class CommonExceptionHandler {
         CommonErrorDto commonErrorDto = new CommonErrorDto(HttpStatus.BAD_REQUEST, e.getMessage());
         return new ResponseEntity<>(commonErrorDto, HttpStatus.BAD_REQUEST);
     }
-
 }

--- a/src/main/java/com/example/coconote/security/config/TokenSecurityConfig.java
+++ b/src/main/java/com/example/coconote/security/config/TokenSecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.coconote.security.config;
 
+import com.example.coconote.api.member.repository.MemberRepository;
 import com.example.coconote.security.filter.JwtAuthenticationFilter;
 import com.example.coconote.security.service.TokenOAuth2UserService;
 import com.example.coconote.security.token.JwtTokenProvider;
@@ -17,6 +18,7 @@ public class TokenSecurityConfig {
 
     private final TokenOAuth2UserService tokenOAuth2UserService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
 
     @Bean
     // 스프링 시큐리티는 이 **SecurityFilterChain**을 통해 필터를 실행하고, 모든 요청에 대해 인증과 인가 규칙을 적용합니다.
@@ -53,7 +55,7 @@ public class TokenSecurityConfig {
                 // JWT 토큰이 유효하다면 폼 로그인을 거치지 않고 바로 인증을 완료할 수 있습니다.
                 // JWT 토큰이 유효하다면, 스프링 시큐리티는 JWT 토큰을 기반으로 사용자를 인증하고, **UsernamePasswordAuthenticationFilter**를 거치지 않고 요청을 처리합니다.
                 // JWT 인증 필터는 요청의 Authorization 헤더에 있는 JWT 토큰을 검증합니다.
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, memberRepository), UsernamePasswordAuthenticationFilter.class
                 );
 
         // HttpSecurity 객체를 사용해 보안 설정을 완료하고, 그 설정을 기반으로 SecurityFilterChain 객체를 생성하여 반환하는 역할

--- a/src/main/java/com/example/coconote/security/controller/TokenController.java
+++ b/src/main/java/com/example/coconote/security/controller/TokenController.java
@@ -24,8 +24,7 @@ public class TokenController {
     private final JwtTokenProvider jwtTokenProvider;
 
     @GetMapping("/token")
-    public ResponseEntity<String> generateToken(
-            @AuthenticationPrincipal OAuth2User oAuth2User) {
+    public ResponseEntity<String> generateToken( @AuthenticationPrincipal OAuth2User oAuth2User) {
 
         // SecurityContext에서 Authentication 객체 가져오기
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
@@ -51,7 +50,6 @@ public class TokenController {
 
         // OAuth2 로그인 성공 후 사용자의 이메일을 가져옴
         if (email == null) {
-            System.out.println("이메일을 가져오지 못했습니다.");
             return ResponseEntity.badRequest().body("Failed to retrieve user information.");
         }
 
@@ -72,10 +70,8 @@ public class TokenController {
 
         // HTTP 바디에서 리프레시 토큰 추출
         String refreshToken = requestBody.get("refreshToken");
-        System.out.println("refreshToken = " + refreshToken);
 
         if (refreshToken == null) {
-            System.out.println("refreshToken is null");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("refresh token is null");
         } else if (!jwtTokenProvider.validateToken(refreshToken)) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid or expired refresh token");
@@ -83,9 +79,6 @@ public class TokenController {
 
         // 리프레시 토큰이 유효하다면 새로운 액세스 토큰 발급
         String newAccessToken = jwtTokenProvider.generateAccessToken(jwtTokenProvider.getEmailFromToken(refreshToken));
-
-        // test code
-        System.out.println("newAccessToken = " + newAccessToken);
 
         // 새로 발급된 액세스 토큰을 클라이언트에게 반환
         return ResponseEntity.ok(newAccessToken);

--- a/src/main/java/com/example/coconote/security/entity/CustomPrincipal.java
+++ b/src/main/java/com/example/coconote/security/entity/CustomPrincipal.java
@@ -1,0 +1,14 @@
+package com.example.coconote.security.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CustomPrincipal {
+    private String email;
+    private Long memberId;
+    private String nickname;
+}

--- a/src/main/java/com/example/coconote/security/service/TokenOAuth2UserService.java
+++ b/src/main/java/com/example/coconote/security/service/TokenOAuth2UserService.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
-
 @Service
 @RequiredArgsConstructor
 public class TokenOAuth2UserService extends DefaultOAuth2UserService {
@@ -41,7 +40,7 @@ public class TokenOAuth2UserService extends DefaultOAuth2UserService {
             throw new IllegalArgumentException("지원하지 않는 로그인 제공자입니다.");
         }
 
-        // 이메일로 DB에서 회원 확인
+        // 이메일로 DB 에서 회원 확인
         Member member = memberRepository.findByEmail(email)
                 .orElseGet(() -> {
                     // 가입된 회원이 없을 경우 새로 생성
@@ -50,7 +49,6 @@ public class TokenOAuth2UserService extends DefaultOAuth2UserService {
                     newMember.setNickname(name);
                     return memberRepository.save(newMember);
                 });
-
         return oAuth2User;
     }
 }

--- a/src/main/java/com/example/coconote/security/token/JwtAuthenticationToken.java
+++ b/src/main/java/com/example/coconote/security/token/JwtAuthenticationToken.java
@@ -1,15 +1,16 @@
 package com.example.coconote.security.token;
 
+import com.example.coconote.security.entity.CustomPrincipal;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
 import java.util.Collections;
 
 public class JwtAuthenticationToken extends UsernamePasswordAuthenticationToken {
 
-    public JwtAuthenticationToken(String principal) {
+    public JwtAuthenticationToken(CustomPrincipal customPrincipal) {
 //        principal: 인증된 사용자(보통 이메일 또는 사용자 ID)를 의미합니다.
 //        credentials: JWT 방식에서는 자격 증명이 필요 없기 때문에 null 로 처리합니다.
-//        authorities: 사용자 권한 정보가 없거나 필요 없을 경우, 빈 리스트로 처리합니다.
-        super(principal, null, Collections.emptyList());  // 권한이 필요 없을 경우 emptyList 로 처리
+//        authorities: 사용자 권한 정보가 없거나 필요 없을 경우, 빈 리스트로 처리합니다. 권한이 필요 없을 경우 emptyList 로 처리
+        super(customPrincipal, null, Collections.emptyList());
     }
 }

--- a/src/main/java/com/example/coconote/security/token/JwtTokenProvider.java
+++ b/src/main/java/com/example/coconote/security/token/JwtTokenProvider.java
@@ -2,16 +2,29 @@ package com.example.coconote.security.token;
 
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 
 @Component
 public class JwtTokenProvider {
 
-    private final Key SECRET_KEY = Keys.secretKeyFor(SignatureAlgorithm.HS512);  // 비밀키 생성
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    private Key SECRET_KEY;
+
+    @PostConstruct
+    public void init() {
+        // Base64로 인코딩된 키를 디코딩한 후 SECRET_KEY 로 변환
+        SECRET_KEY = new SecretKeySpec(secretKey.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.HS512.getJcaName());
+    }
+
     private final long ACCESS_TOKEN_EXPIRATION_TIME = 15 * 60 * 1000;  // 15분
     private final long REFRESH_TOKEN_EXPIRATION_TIME = 7 * 24 * 60 * 60 * 1000;  // 7일
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -72,3 +72,6 @@ aws:
   s3:
     region: ${local.s3.region}
     bucket: ${local.s3.bucket}
+
+jwt:
+  secret: ${local.jwt.secret}


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [x ] 기능 추가
- [ ] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
로그인 사용자의 정보를 어노테이션을 이용해서 파라미터로 받을 수 있는 기능 추가.
메소드의 파라미터에 @AuthenticationPrincipal CustomPrincipal customPrincipal 를 추가.
customPrincipal.getEmail(), getMemberId(), getNickname() 사용 가능.

기존에는 SecurityContextHolder에 저장할 때, JwtAuthenticationToken에 이메일을 String으로 저장했지만
CustomPrincipal 클래스를 만들어서 객체로 추가하여 원하는 정보를 담을 수 있게됨.

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->
![image](https://github.com/user-attachments/assets/e18bdaf1-f0a1-4015-aea6-4ee33d19153c)
![image](https://github.com/user-attachments/assets/2fa2ac40-d71b-4bde-a940-9e13eef7077d)

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/HC-109