### PR TITLE
[Fix] HC-46 KafkaThreadConfig 중복되는 이름의 메소드 수정

### DIFF
--- a/src/main/java/com/example/coconote/api/thread/controller/WebSocketController.java
+++ b/src/main/java/com/example/coconote/api/thread/controller/WebSocketController.java
@@ -20,7 +20,7 @@ public class WebSocketController {
 
     private final SimpMessageSendingOperations messagingTemplate;
     private final ThreadService threadService;
-    private final KafkaTemplate<String, ThreadCreateReqDto> kafkaTemplate;
+    private final KafkaTemplate<String, ThreadCreateReqDto> kafkaThreadTemplate;
 
     @MessageMapping("/chat/message")
     public void message(ThreadCreateReqDto message) {
@@ -29,7 +29,7 @@ public class WebSocketController {
 
 //        ThreadResDto threadResDto = threadService.createThread(message);
 
-        kafkaTemplate.send("chat_topic", message.getChannelId().toString(), message);
+        kafkaThreadTemplate.send("chat_topic", message.getChannelId().toString(), message);
 //        messagingTemplate.convertAndSend("/sub/chat/room/" + message.getChannelId(), threadResDto);
     }
 

--- a/src/main/java/com/example/coconote/config/KafkaThreadConfig.java
+++ b/src/main/java/com/example/coconote/config/KafkaThreadConfig.java
@@ -23,7 +23,7 @@ public class KafkaThreadConfig {
     private String bootstrapServers;
     // Producer Configuration
     @Bean
-    public ProducerFactory<String, ThreadCreateReqDto> producerFactory() {
+    public ProducerFactory<String, ThreadCreateReqDto> producerThreadFactory() {
         Map<String, Object> configs = new HashMap<>();
         configs.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -31,12 +31,12 @@ public class KafkaThreadConfig {
         return new DefaultKafkaProducerFactory<>(configs);
     }
     @Bean
-    public KafkaTemplate<String, ThreadCreateReqDto> kafkaTemplate() {
-        return new KafkaTemplate<>(producerFactory());
+    public KafkaTemplate<String, ThreadCreateReqDto> kafkaThreadTemplate() {
+        return new KafkaTemplate<>(producerThreadFactory());
     }
     // Consumer Configuration
     @Bean
-    public ConsumerFactory<String, ThreadCreateReqDto> consumerFactory() {
+    public ConsumerFactory<String, ThreadCreateReqDto> consumerThreadFactory() {
         return new DefaultKafkaConsumerFactory<>(
                 consumerConfigurations(),
                 new StringDeserializer(),
@@ -54,9 +54,9 @@ public class KafkaThreadConfig {
         return configurations;
     }
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, ThreadCreateReqDto> kafkaListenerContainerFactory() {
+    public ConcurrentKafkaListenerContainerFactory<String, ThreadCreateReqDto> kafkaThreadListenerContainerFactory() {
         ConcurrentKafkaListenerContainerFactory<String, ThreadCreateReqDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(consumerFactory());
+        factory.setConsumerFactory(consumerThreadFactory());
         return factory;
     }
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
- HC-46 KafkaThreadConfig 중복되는 이름의 메소드 수정

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/HC-46