### PR TITLE
[FIX] HC-136 채널 생성시 디폴트 폴더 "채널, 쓰레드",추가 완료 디폴트 폴더는 수정 이동 삭제 불가능 하도록 설정

### DIFF
--- a/src/main/java/com/example/coconote/api/channel/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/coconote/api/channel/channel/controller/ChannelController.java
@@ -61,8 +61,8 @@ public class ChannelController {
 
     @Operation(summary= "채널 에 속한 드라이브로 이동")
     @GetMapping("/channel/{id}/drive")
-    public ResponseEntity<Object> channelDrive(@PathVariable Long id, String email) {
-        FolderAllListResDto resDto = channelService.channelDrive(id, email);
+    public ResponseEntity<Object> channelDrive(@PathVariable Long id, @AuthenticationPrincipal CustomPrincipal customPrincipal) {
+        FolderAllListResDto resDto = channelService.channelDrive(id, customPrincipal.getEmail());
         CommonResDto commonResDto = new CommonResDto(HttpStatus.OK, "channel is successfully moved to drive", resDto);
         return new ResponseEntity<>(commonResDto, HttpStatus.OK);
     }

--- a/src/main/java/com/example/coconote/api/channel/channel/service/ChannelService.java
+++ b/src/main/java/com/example/coconote/api/channel/channel/service/ChannelService.java
@@ -78,12 +78,18 @@ public class ChannelService {
                 .channel(channel)
                 .build();
         Folder folder = Folder.builder()
-                .folderName("자동업로드 폴더")
+                .folderName("캔버스 자동업로드 폴더")
+                .channel(channel)
+                .parentFolder(rootFolder)
+                .build();
+        Folder folder2 = Folder.builder()
+                .folderName("쓰레드 자동업로드 폴더")
                 .channel(channel)
                 .parentFolder(rootFolder)
                 .build();
         folderRepository.save(rootFolder);
         folderRepository.save(folder);
+        folderRepository.save(folder2);
     }
 
     public List<ChannelDetailResDto> channelList(Long sectionId) {

--- a/src/main/java/com/example/coconote/api/drive/dto/response/FileListDto.java
+++ b/src/main/java/com/example/coconote/api/drive/dto/response/FileListDto.java
@@ -15,6 +15,7 @@ import java.util.List;
 public class FileListDto {
     private Long fileId;
     private String fileName;
+    private String fileUrl;
     private String creator;
     private String createdDate;
 
@@ -23,6 +24,7 @@ public class FileListDto {
                 .map(fileEntity -> FileListDto.builder()
                         .fileId(fileEntity.getId())
                         .fileName(fileEntity.getFileName())
+                        .fileUrl(fileEntity.getFileUrl())
                         .creator(fileEntity.getCreator().getNickname())
                         .createdDate(fileEntity.getCreatedTime().toString())
                         .build())

--- a/src/main/java/com/example/coconote/api/drive/repository/FolderRepository.java
+++ b/src/main/java/com/example/coconote/api/drive/repository/FolderRepository.java
@@ -26,4 +26,5 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 
     Optional<Folder> findByChannelAndParentFolderIsNull(Channel channel);
 
+    Optional<Folder> findByChannelAndFolderName(Channel channel, String folderName);
 }

--- a/src/main/java/com/example/coconote/api/drive/service/FolderService.java
+++ b/src/main/java/com/example/coconote/api/drive/service/FolderService.java
@@ -62,6 +62,9 @@ public class FolderService {
         Member member = getMemberByEmail(email);
         Folder folder = getFolderByFolderId(folderId);
         Channel channel = getChannelByChannelId(folder.getChannel().getChannelId());
+        if(folder.getFolderName().equals("캔버스 자동업로드 폴더") || folder.getFolderName().equals("쓰레드 자동업로드 폴더")){
+            throw new IllegalArgumentException("이 폴더는 이름을 변경할 수 없습니다.");
+        }
 //        채널 멤버인지 확인
         checkChannelMember(member, channel);
 
@@ -74,6 +77,11 @@ public class FolderService {
         Member member = getMemberByEmail(email);
         Folder folder = getFolderByFolderId(folderId);
         Channel channel = getChannelByChannelId(folder.getChannel().getChannelId());
+
+        if(folder.getFolderName().equals("캔버스 자동업로드 폴더") || folder.getFolderName().equals("쓰레드 자동업로드 폴더")){
+            throw new IllegalArgumentException("이 폴더는 삭제할 수 없습니다.");
+        }
+
 //        채널 멤버인지 확인
         checkChannelMember(member, channel);
 //        자식 폴더들도 재귀적으로 삭제 처리
@@ -93,6 +101,10 @@ public class FolderService {
         Channel parentChannel = getChannelByChannelId(parentFolder.getChannel().getChannelId());
         if (!channel.getChannelId().equals(parentChannel.getChannelId())) {
             throw new IllegalArgumentException("폴더가 서로 다른 채널에 있습니다.");
+        }
+
+        if(folder.getFolderName().equals("캔버스 자동업로드 폴더") || folder.getFolderName().equals("쓰레드 자동업로드 폴더")){
+            throw new IllegalArgumentException("이 폴더는 삭제할 수 없습니다.");
         }
 //        채널 멤버인지 확인
         checkChannelMember(member, parentFolder.getChannel());

--- a/src/main/java/com/example/coconote/global/fileUpload/dto/request/FileMetadataReqDto.java
+++ b/src/main/java/com/example/coconote/global/fileUpload/dto/request/FileMetadataReqDto.java
@@ -1,5 +1,6 @@
 package com.example.coconote.global.fileUpload.dto.request;
 
+import com.example.coconote.global.fileUpload.entity.FileType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -15,4 +16,5 @@ public class FileMetadataReqDto {
     private Long channelId;
     private Long folderId;
     private List<FileSaveListDto> fileSaveListDto;
+    private FileType fileType;  // Enum 필드 추가
 }

--- a/src/main/java/com/example/coconote/global/fileUpload/entity/FileType.java
+++ b/src/main/java/com/example/coconote/global/fileUpload/entity/FileType.java
@@ -1,0 +1,7 @@
+package com.example.coconote.global.fileUpload.entity;
+
+public enum FileType {
+    THREAD,
+    CANVAS,
+    OTHER
+}


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
- 채널 생성시 디폴트 폴더 "채널, 쓰레드",추가 완료
- 디폴트 폴더는 수정 이동 삭제 불가능 하도록 설정
