### PR TITLE
[FIX] 캔버스 삭제 시 연결된 canvas를 못 불러오는 현상

### DIFF
--- a/src/main/java/com/example/coconote/api/canvas/canvas/repository/CanvasRepository.java
+++ b/src/main/java/com/example/coconote/api/canvas/canvas/repository/CanvasRepository.java
@@ -19,5 +19,5 @@ public interface CanvasRepository extends JpaRepository<Canvas,Long> {
     List<Canvas> findByParentCanvasIdAndIsDeleted(Long parentCanvasId, IsDeleted isDeleted);
     List<Canvas> findByParentCanvasIdAndChannelAndIsDeleted(Long parentCanvasId, Channel channel, IsDeleted isDeleted);
 
-    Optional<Canvas> findByPrevCanvasIdAndIsDeleted(Long id, IsDeleted isDeleted);
+    Optional<Canvas> findByPrevCanvas_IdAndIsDeleted(Long id, IsDeleted isDeleted);
 }


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
1. 캔버스의 prevCanvas를 못 불러와서 추가 작업

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
feat/HC-206