### PR TITLE
fix/HC-110 채널 공개범위 변경 방식 수정, 워크스페이스, 채널 재가입시 탈퇴 전 기존 정보 불러오게 수정

### DIFF
--- a/src/main/java/com/example/coconote/api/channel/channel/controller/ChannelController.java
+++ b/src/main/java/com/example/coconote/api/channel/channel/controller/ChannelController.java
@@ -1,5 +1,6 @@
 package com.example.coconote.api.channel.channel.controller;
 
+import com.example.coconote.api.channel.channel.dto.request.ChannelAccessReqDto;
 import com.example.coconote.api.channel.channel.dto.request.ChannelCreateReqDto;
 import com.example.coconote.api.channel.channel.dto.request.ChannelUpdateReqDto;
 import com.example.coconote.api.channel.channel.dto.response.ChannelDetailResDto;
@@ -62,17 +63,13 @@ public class ChannelController {
     }
 
     @Operation(summary= "채널 공개 범위 수정")
-    @PatchMapping("/channel/access/{id}")
-    public ResponseEntity<Object> channelChangeAccessLevel(@PathVariable Long id, @AuthenticationPrincipal CustomPrincipal customPrincipal) {
-        CommonResDto commonResDto;
-        Boolean value = channelService.channelChangeAccessLevel(id, customPrincipal.getEmail());
-        if(value) {
-            commonResDto = new CommonResDto(HttpStatus.OK, "access level of this channel is now public", value);
-        }else{
-            commonResDto = new CommonResDto(HttpStatus.OK, "access level of this channel is now private", value);
-        }
+    @PatchMapping("/channel/access")
+    public ResponseEntity<Object> channelChangeAccessLevel(@RequestBody ChannelAccessReqDto dto, @AuthenticationPrincipal CustomPrincipal customPrincipal) {
+        ChannelDetailResDto resDto = channelService.channelChangeAccessLevel(dto, customPrincipal.getEmail());
+        CommonResDto commonResDto = new CommonResDto(HttpStatus.OK, "channel is successfully updated", resDto);
         return new ResponseEntity<>(commonResDto, HttpStatus.OK);
     }
+
 
     @Operation(summary= "채널 삭제")
     @DeleteMapping("/channel/delete/{id}") // 댓글 삭제

--- a/src/main/java/com/example/coconote/api/channel/channel/dto/request/ChannelAccessReqDto.java
+++ b/src/main/java/com/example/coconote/api/channel/channel/dto/request/ChannelAccessReqDto.java
@@ -1,0 +1,15 @@
+package com.example.coconote.api.channel.channel.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChannelAccessReqDto {
+    private Long channelId;
+    private Boolean isPublic;
+}

--- a/src/main/java/com/example/coconote/api/channel/channel/entity/Channel.java
+++ b/src/main/java/com/example/coconote/api/channel/channel/entity/Channel.java
@@ -81,9 +81,9 @@ public class Channel extends BaseEntity {
         this.channelInfo = dto.getChannelInfo();
     }
 
-    public Boolean changeAccessLevel() {
-        this.isPublic = !this.isPublic;
-        return this.isPublic;
+    public ChannelDetailResDto changeAccessLevel(Boolean isPublic) {
+        this.isPublic = isPublic;
+        return this.fromEntity(this.getSection());
     }
 
     public void deleteEntity() {

--- a/src/main/java/com/example/coconote/api/channel/channelMember/entity/ChannelMember.java
+++ b/src/main/java/com/example/coconote/api/channel/channelMember/entity/ChannelMember.java
@@ -77,8 +77,9 @@ public class ChannelMember extends BaseEntity {
         this.deletedTime = LocalDateTime.now();
     }
 
-    public void undeleteEntity() {
+    public void restoreEntity() {
         this.isDeleted = IsDeleted.N;
         this.deletedTime = null;
     }
+
 }

--- a/src/main/java/com/example/coconote/api/channel/channelMember/service/ChannelMemberService.java
+++ b/src/main/java/com/example/coconote/api/channel/channelMember/service/ChannelMemberService.java
@@ -38,8 +38,6 @@ public class ChannelMemberService {
     public ChannelMemberService(ChannelMemberRepository channelMemberRepository,
                                 WorkspaceMemberRepository workspaceMemberRepository,
                                 ChannelRepository channelRepository,
-                                SectionRepository sectionRepository,
-                                WorkspaceRepository workspaceRepository,
                                 MemberRepository memberRepository) {
         this.channelMemberRepository = channelMemberRepository;
         this.workspaceMemberRepository = workspaceMemberRepository;
@@ -68,15 +66,14 @@ public class ChannelMemberService {
             return newChannelMember.fromEntity();
         } else {
             ChannelMember channelMember = optionalChannelMember.get();
-            if (channelMember.getIsDeleted().equals(IsDeleted.N)) {
-                throw new IllegalArgumentException("이미 채널에 가입되어 있는 회원입니다.");
-            } else if (channelMember.getIsDeleted().equals(IsDeleted.Y)) {
+            if (channelMember.getIsDeleted().equals(IsDeleted.Y)) {
                 channelMember.restoreEntity();
                 channelMemberRepository.save(channelMember);
                 return channelMember.fromEntity();
+            } else {
+                throw new IllegalArgumentException("이미 채널에 가입되어 있는 회원입니다.");
             }
         }
-        return null;
     }
 
     public List<ChannelMemberListResDto> channelMemberList(Long channelId) {

--- a/src/main/java/com/example/coconote/api/channel/channelMember/service/ChannelMemberService.java
+++ b/src/main/java/com/example/coconote/api/channel/channelMember/service/ChannelMemberService.java
@@ -71,7 +71,7 @@ public class ChannelMemberService {
             if (channelMember.getIsDeleted().equals(IsDeleted.N)) {
                 throw new IllegalArgumentException("이미 채널에 가입되어 있는 회원입니다.");
             } else if (channelMember.getIsDeleted().equals(IsDeleted.Y)) {
-                channelMember.undeleteEntity();
+                channelMember.restoreEntity();
                 channelMemberRepository.save(channelMember);
                 return channelMember.fromEntity();
             }
@@ -154,6 +154,11 @@ public class ChannelMemberService {
 //        같은 워크스페이스의 회원만 초대 가능
         if (!Objects.equals(selfWorkspaceMember.getWorkspace().getWorkspaceId(), workspaceMember.getWorkspace().getWorkspaceId())) {
             throw new IllegalArgumentException("같은 워크스페이스의 회원만 초대할 수 있습니다.");
+        }
+        if(channelMemberRepository.findByChannelAndWorkspaceMemberAndIsDeleted(channel, workspaceMember, IsDeleted.Y).isPresent()) {
+            ChannelMember channelMemberCameBack = channelMemberRepository.findByChannelAndWorkspaceMemberAndIsDeleted(channel, workspaceMember, IsDeleted.Y).orElseThrow(()-> new EntityNotFoundException("없는 채널 회원입니다."));
+            channelMemberCameBack.restoreEntity();
+            return channelMemberCameBack.fromEntity();
         }
         ChannelMember channelMember = ChannelMember.builder()
                 .channel(channel)

--- a/src/main/java/com/example/coconote/api/workspace/workspaceMember/entity/WorkspaceMember.java
+++ b/src/main/java/com/example/coconote/api/workspace/workspaceMember/entity/WorkspaceMember.java
@@ -104,4 +104,9 @@ public class WorkspaceMember extends BaseEntity {
     public void changeProfileImage(String profileImage) {
         this.profileImage = profileImage;
     }
+
+    public void restoreEntity() {
+        this.isDeleted = IsDeleted.N;
+        this.deletedTime = null;
+    }
 }

--- a/src/main/java/com/example/coconote/api/workspace/workspaceMember/service/WorkspaceMemberService.java
+++ b/src/main/java/com/example/coconote/api/workspace/workspaceMember/service/WorkspaceMemberService.java
@@ -55,6 +55,11 @@ public class WorkspaceMemberService {
         if(workspaceMemberRepository.findByMemberAndWorkspaceAndIsDeleted(member, workspace, IsDeleted.N).isPresent()) {
             throw new IllegalArgumentException("이미 워크스페이스에 가입되어 있는 회원입니다.");
         }
+        if(workspaceMemberRepository.findByMemberAndWorkspaceAndIsDeleted(member, workspace, IsDeleted.Y).isPresent()) {
+            WorkspaceMember workspaceMemberCameBack = workspaceMemberRepository.findByMemberAndWorkspaceAndIsDeleted(member, workspace, IsDeleted.Y).orElseThrow(()-> new EntityNotFoundException("없는 회원입니다."));
+            workspaceMemberCameBack.restoreEntity();
+            return workspaceMemberCameBack.fromEntity();
+        }
 
         WorkspaceMember workspaceMember = WorkspaceMember.builder()
                 .workspace(workspace)


### PR DESCRIPTION
## 📌 PR 타입
<!-- [x] 이렇게하면 체크돼요 -->
- [ ] 기능 추가
- [x] 기능 수정
- [ ] 리팩토링
- [ ] docs 작업


## 📄 작업 내용
<!-- ex) 구글 소셜 로그인 기능추가, 프로젝트 모집글 쓰기 API 작성 -->
채널 공개범위 직접 값으로 사용자가 직접 선택하게 수정
워크스페이스, 채널 탈퇴 후 재가입시 이메일 검증 후 기존 회원 정보 불러오기(DelYN N->Y)

## 📷 결과 화면
<!-- 포스트맨 실행결과를 캡처해주세요 -->

## ✔️ 기타 사항
<!-- 리뷰 받고 싶은 포인트를 적어주세요! -->

## 🌳 작업 브랜치
<!--ex)  feat/IS-1  -->
